### PR TITLE
Fix buffered messages when no clients.

### DIFF
--- a/src/main/java/org/gridsuite/notification/server/NotificationWebSocketHandler.java
+++ b/src/main/java/org/gridsuite/notification/server/NotificationWebSocketHandler.java
@@ -73,6 +73,10 @@ public class NotificationWebSocketHandler implements WebSocketHandler {
             ConnectableFlux<Message<String>> c = f.log(CATEGORY_BROKER_INPUT, Level.FINE).publish();
             this.flux = c;
             c.connect();
+            // Force connect 1 fake subscriber to consumme messages as they come.
+            // Otherwise, reactorcore buffers some messages (not until the connectable flux had
+            // at least one subscriber. Is there a better way ?
+            c.subscribe();
         };
     }
 


### PR DESCRIPTION
We want to discard them, not replay them on the next connected client

Signed-off-by: Jon Harper <jon.harper87@gmail.com>