### PR TITLE
Restore use of "node" in notifications headers

### DIFF
--- a/src/main/java/org/gridsuite/notification/server/NotificationWebSocketHandler.java
+++ b/src/main/java/org/gridsuite/notification/server/NotificationWebSocketHandler.java
@@ -59,6 +59,7 @@ public class NotificationWebSocketHandler implements WebSocketHandler {
     static final String HEADER_SUBSTATIONS_IDS = "substationsIds";
     static final String HEADER_DELETED_EQUIPMENT_ID = "deletedEquipmentId";
     static final String HEADER_DELETED_EQUIPMENT_TYPE = "deletedEquipmentType";
+    static final String HEADER_NODE = "node";
     static final String HEADER_NODES = "nodes";
     static final String HEADER_PARENT_NODE = "parentNode";
     static final String HEADER_NEW_NODE = "newNode";
@@ -132,6 +133,7 @@ public class NotificationWebSocketHandler implements WebSocketHandler {
         passHeader(messageHeader, resHeader, HEADER_PARENT_NODE);
         passHeader(messageHeader, resHeader, HEADER_INSERT_MODE);
         passHeader(messageHeader, resHeader, HEADER_REMOVE_CHILDREN);
+        passHeader(messageHeader, resHeader, HEADER_NODE);
         passHeader(messageHeader, resHeader, HEADER_NODES);
         passHeader(messageHeader, resHeader, HEADER_NEW_NODE);
 

--- a/src/test/java/org/gridsuite/notification/server/NotificationWebSocketHandlerTest.java
+++ b/src/test/java/org/gridsuite/notification/server/NotificationWebSocketHandlerTest.java
@@ -135,6 +135,7 @@ public class NotificationWebSocketHandlerTest {
 
                 Map.of(HEADER_STUDY_UUID, "nodes", HEADER_UPDATE_TYPE, "insert", HEADER_PARENT_NODE, UUID.randomUUID().toString(), HEADER_NEW_NODE, UUID.randomUUID().toString(), HEADER_INSERT_MODE, true),
                 Map.of(HEADER_STUDY_UUID, "nodes", HEADER_UPDATE_TYPE, "update", HEADER_NODES, List.of(UUID.randomUUID().toString())),
+                Map.of(HEADER_STUDY_UUID, "nodes", HEADER_UPDATE_TYPE, "update", HEADER_NODE, UUID.randomUUID().toString()),
                 Map.of(HEADER_STUDY_UUID, "nodes", HEADER_UPDATE_TYPE, "delete", HEADER_NODES, List.of(UUID.randomUUID().toString()),
                     HEADER_PARENT_NODE, UUID.randomUUID().toString(), HEADER_REMOVE_CHILDREN, true))
                 .map(map -> new GenericMessage<>("", map))
@@ -186,6 +187,7 @@ public class NotificationWebSocketHandlerTest {
         passHeaderRef(messageHeader, resHeader, HEADER_DELETED_EQUIPMENT_ID);
         passHeaderRef(messageHeader, resHeader, HEADER_DELETED_EQUIPMENT_TYPE);
         passHeaderRef(messageHeader, resHeader, HEADER_NEW_NODE);
+        passHeaderRef(messageHeader, resHeader, HEADER_NODE);
         passHeaderRef(messageHeader, resHeader, HEADER_NODES);
         passHeaderRef(messageHeader, resHeader, HEADER_REMOVE_CHILDREN);
         passHeaderRef(messageHeader, resHeader, HEADER_PARENT_NODE);


### PR DESCRIPTION
Signed-off-by: sBouzols <sylvain.bouzols@gmail.com>